### PR TITLE
Update documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NbodyGradient"
 uuid = "69f646f0-5709-4f35-9e52-1656edff0883"
 authors = ["Eric Agol <agol@uw.edu>", "David Hernandez", "Zach Langford <langfzac@uw.edu>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,15 @@
 using Documenter, NbodyGradient
 
 makedocs(sitename="NbodyGradient",
+    modules = [NbodyGradient],
     format = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true"
-    )
+    ),
+    pages = [
+        "Index" => "index.md",
+        "Tutorials" => ["basic.md", "gradients.md"],
+        "API" => "api.md"
+    ]
 )
 
 deploydocs(

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,10 +4,11 @@
 
 ### Initial Conditions
 ```@docs
+CartesianIC
 Elements
 Elements(m::T,P::T,t0::T,ecosϖ::T,esinϖ::T,I::T,Ω::T) where T<:Real
 ElementsIC
-ElementsIC(t0::T,H::Union{Int64,Vector{Int64}},elems::Elements{T}...) where T <: AbstractFloat
+ElementsIC(t0::T, H::Matrix{<:Real}, elems::Elements{T}...) where T<:AbstractFloat
 ```
 
 ### State
@@ -19,4 +20,12 @@ State(ic::InitialConditions{T}) where T<:AbstractFloat
 ### Integrator
 ```@docs
 Integrator{T<:AbstractFloat}
+```
+
+### TransitTiming
+```@docs
+TransitParameters{T<:AbstractFloat}
+TransitParameters(tmax::T,ic::ElementsIC{T},ti::Int64=1) where T<:AbstractFloat
+TransitTiming{T<:AbstractFloat}
+TransitTiming(tmax::T,ic::ElementsIC{T},ti::Int64=1) where T<:AbstractFloat
 ```

--- a/docs/src/basic.md
+++ b/docs/src/basic.md
@@ -1,7 +1,5 @@
-# Examples
-
-## Basic Usage
-Here we'll walk through a simple example of integrating a 3-body system.
+# Basic Usage
+Here we'll walk through an example of integrating a 3-body system.
 ##### Units
 A quick note on the units used throughout the code.
 - Distance: AU
@@ -12,33 +10,40 @@ A quick note on the units used throughout the code.
 ### Initial Conditions
 First, we define the orbital elements of the system. This can be done by creating [`Elements`](@ref) for each body in the system.
 
-Start with a 1 solar mass
+Start with a 1 solar mass star
 ```@example 1
-using NbodyGradient # hide
+using NbodyGradient
+
 a = Elements(m = 1.0);
 nothing # hide
 ```
 
-We then define the orbital elements for first body, say an Earth analogue.
+We then define the orbital elements for second body, say an Earth analogue.
 ```@example 1
 b = Elements(
-    m = 3e-6,
-    P = 365.256,
-    ecosϖ = 0.01
+    m = 3e-6,     # Mass [Solar masses]
+    t0 = 0.0,     # Initial time of transit [days]
+    P = 365.256,  # Period [days]
+    ecosϖ = 0.01, # Eccentricity * cos(Argument of Periastron)
+    esinϖ = 0.0,  # Eccentricity * sin(Argument of Periastron)
+    I = π/2,      # Inclination [Radians]
+    Ω = 0.0       # Longitude of Ascending Node [Radians]
 );
 nothing # hide
 ```
-The unspecified orbital elements default to zeros. (`ecosϖ` can be typed as `ecos\varpi` and then hitting tab)
+(`ecosϖ` can be typed as `ecos\varpi` and then hitting tab)
 
 Next we'll create a Jupiter analogue for the final body. Here the orbital elements are specified for the Keplerian ((a,b),c), or c orbiting the center of mass of a and b. (While this might not need to be stated explicitly here, this convention is useful for more complicated hierarchical systems).
 ```@example 1
 c = Elements(
     m = 9.54e-4,
     P = 4332.59,
-    ecosϖ = 0.05
+    ecosϖ = 0.05,
+    I = π/2
 );
 nothing # hide
 ```
+Here, we can simply omit any orbital elements which are zero. Unspecified elements are set to zero by default.
 
 Now we need to pass our [`Elements`](@ref) to [`ElementsIC`](@ref).
 ```@example 1
@@ -60,12 +65,11 @@ s.x
 ```
 
 ### Integration
-Now that we have initial conditions, we can construct and run the integrator. First, define an [`Integrator`](@ref), specifying the integration scheme, the time step, initial time, and final time. We'll use the `ahl21!` mapping.
+Now that we have initial conditions, we can construct and run the integrator. First, define an [`Integrator`](@ref), specifying the integration scheme, the time step, and final time. We'll use the `ahl21!` mapping.
 ```@example 1
 h = b.P/30.0 # We want at most 1/20th of the smallest period for a time step
-t0 = 0.0
 tmax = 5*c.P # Integrate for 5 orbital periods of the outer body
-intr = Integrator(ahl21!,h,t0,tmax);
+intr = Integrator(ahl21!,h,tmax);
 nothing # hide
 ```
 
@@ -74,12 +78,22 @@ Finally, run the [`Integrator`](@ref) by passing it the [`State`](@ref).
 intr(s)
 s.x # Show final positions
 ```
-This integrates from `t0` to `tmax`, steping by `h`. If you'd rather step a certain number of time steps:
+This integrates from `s.t` to `s.t+tmax`, steping by `h`. If you'd rather step a certain number of time steps:
 ```@example 1
 N = 1000
 intr(s,N)
 ```
-**Note:** If you want to run the integration from the initial condtions again, you must 'reset' the [`State`](@ref). I.e. run `s = State(ic)`. Otherwise, the integration will begin from what ever `s.t` is currently equal to, and with those coordinates.
+!!! note "Re-running simulations"
+    If you want to run the integration from the initial condtions again, you must 'reset' the [`State`](@ref). I.e. run `s = State(ic)`. Otherwise, the integration will begin from what ever `s.t` is currently equal to, and with those coordinates.
 
 ### Transit Timing
-TBD. For a transit timing example notebook, see examples on GitHub: [NbodyGradient](https://github.com/ericagol/NbodyGradient).
+If we wish to compute transit times, we need only to pass a [`TransitTiming`](@ref)structure to the [`Integrator`](@ref).
+```@example 1
+s = State(ic) # Reset to the initial conditions
+tt = TransitTiming(tmax, ic)
+intr(s,tt)
+```
+To see the first 5 transit times of our second body about the first body, run:
+```@example 1
+tt.tt[2,1:5]
+```

--- a/docs/src/basic.md
+++ b/docs/src/basic.md
@@ -73,6 +73,9 @@ intr = Integrator(ahl21!,h,tmax);
 nothing # hide
 ```
 
+!!! note "A quick aside on constructors"
+    The types in NbodyGradient.jl have a number of constructors that enable to user to write as terse or as verbose code as they would like. For example, the above `Integrator` construction could specify each field as `Integrator(scheme, h, t0, tmax)` (see [`Integrator`](@ref) for argument definitions), or only the time step and integration time as `Integrator(h,tmax)`. In the latter case, the default value for `scheme` and `t0` are `ahl21!` and `0`, respectively. If you're coming from [Agol, Hernandez, and Langford (2021)](https://ui.adsabs.harvard.edu/abs/2021arXiv210602188A/abstract) you'll notice some discrepancy in the examples due to this.
+
 Finally, run the [`Integrator`](@ref) by passing it the [`State`](@ref).
 ```@example 1
 intr(s)

--- a/docs/src/gradients.md
+++ b/docs/src/gradients.md
@@ -1,0 +1,40 @@
+# Gradients
+The main purpose of developing NbodyGradient.jl is to provide a differentiable N-body model for gradient-based optimization. Here, we walk though computing and accessing the jacobian of the transit times with respect to the initial orbital elements and masses.
+
+We assume you've taken a look at the [Basic Usage](@ref) tutorial, and are familiar with the orbital elements and units used in NbodyGradient.jl.
+
+Here, we will specify the orbital elements using the 'elements matrix' option (See [`ElementsIC`](@ref)).
+```@example 2
+using NbodyGradient
+
+# Initial Conditions
+elements = [
+  # m    P       t0  ecosϖ esinϖ I   Ω
+    1.0  0.0     0.0 0.0   0.0   0.0 0.0; # Star
+    3e-6 365.256 0.0 0.01  0.0   π/2 0.0; # Earth analogue
+]
+ic = ElementsIC(0.0, 2, elements);
+nothing # hide
+```
+
+Let's integrate for 5 periods of the planet and record the transit times.
+```@example 2
+s = State(ic)
+
+P = elements[2,2] # Get the period from the elements matrix
+tmax = 5 * P
+tt = TransitTiming(5 * P, ic)
+
+h = P/30.0
+Integrator(h, tmax)(s, tt) # Run without creating an `Integrator` variable.
+
+# Computed transit times
+tt.tt
+```
+
+The derivatives of the transit times with respect to the initial orbitial elements and masses are held in the `dtdelements` field of the [`TransitTiming`](@ref) structure -- an `Array{T<:AbstractFloat,4}`. The indices correspond to the transiting body, transit number, orbital element, and body the orbital element is describing. For example, this is how to access the 'gradient' of the first transit time of the orbiting body:
+
+```@example 2
+tt.dtdelements[2,1,:,:]
+```
+Here, the first column is the derivative of the transit time with respect to the stars 'orbital elements', which are all zero except for the mass in the last row. The second column is the derivatives with respect to the orbital elements of the system.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,19 +1,30 @@
 # NbodyGradient
-A differentiable N-body integrator for modeling transiting exoplanets, and more.
+A fast, differentiable N-body integrator for modeling transiting exoplanets, and more.
+
+This package provides a simple user-interface to carry out N-body simulations and compute the derivatives of the outputs with respect to the initial conditions. The current version of the code implements the following:
+- Integrators:
+    - AHL21 (4th-order Symplectic; [Agol, Hernandez, & Langford 2021](https://github.com/langfzac/nbg-papers))
+- Initial Conditions:
+    - Cartesian coordinates ([`CartesianIC`](@ref))
+    - Orbital elements ([`ElementsIC`](@ref))
+- Output Models:
+    - Transit times ([`TransitTiming`](@ref))
+    - Transit times, impact parameter, and sky-plane velocity ([`TransitParameters`](@ref))
 
 ## Getting Started
-The code is currently under developement, but the main branch is kept stable. The best way to use the code is to run the following in the REPL
+First, you'll need to add the package. Using the Julia REPL, run:
 ```julia
-]add https://github.com/ericagol/NbodyGradient
+pkg> add NbodyGradient
 ```
-Then use like any other Julia package
+
+If you'd like to use the developement version of the code, run:
+```julia
+pkg> add NbodyGradient#master
+```
+
+Then, use like any other Julia package
 ```julia
 using NbodyGradient
 ```
 
-See the [Examples](@ref) page for basic usage.
-
-## Index
-
-```@index
-```
+See the [Tutorials](@ref) page for basic usage.

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -1,0 +1,5 @@
+# Tutorials
+
+```@contents
+Pages = ["basic.md", "gradients.md"]
+```

--- a/src/ics/InitialConditions.jl
+++ b/src/ics/InitialConditions.jl
@@ -3,7 +3,7 @@ abstract type AbstractInitialConditions end
 """
     Elements{T<:AbstractFloat} <: AbstractInitialConditions
 
-Orbital elements of a binary, and mass of a 'outer' body. See [Examples](@ref) for units and conventions.
+Orbital elements of a binary, and mass of a 'outer' body. See [Tutorials](@ref) for units and conventions.
 
 # Fields
 - `m::T` : Mass of outer body.
@@ -33,7 +33,7 @@ end
 """
     Elements(m,P,t0,ecosϖ,esinϖ,I,Ω)
 
-Main [`Elements`](@ref) constructor. May use keyword arguments, see [Examples](@ref).
+Main [`Elements`](@ref) constructor. May use keyword arguments, see [Tutorials](@ref).
 """
 function Elements(m::T,P::T,t0::T,ecosϖ::T,esinϖ::T,I::T,Ω::T) where T<:Real
     e = sqrt(ecosϖ^2 + esinϖ^2)
@@ -68,7 +68,7 @@ Initial conditions, specified by a hierarchy vector and orbital elements.
 # Fields
 - `elements::Matrix{T}` : Masses and orbital elements.
 - `ϵ::Matrix{T}` : Matrix of Jacobi coordinates
-- `amat::Matrix{T}` : A matrix from [Hamers and Portegies Zwart 2016](https://doi.org/10.1093/mnras/stw784).
+- `amat::Matrix{T}` : 'A' matrix from [Hamers and Portegies Zwart 2016](https://doi.org/10.1093/mnras/stw784).
 - `nbody::Int64` : Number of bodies.
 - `m::Vector{T}` : Masses of bodies.
 - `t0::T` : Initial time [Days].
@@ -92,18 +92,30 @@ end
 ElementsIC(t0::T, H::Matrix{<:Real}, elements::Matrix{T}) where T<:Real = ElementsIC(t0, T.(H), elements)
 
 """
-    ElementsIC(t0,H,elems...)
+    ElementsIC(t0,H,elems)
 
 Collects `Elements` and produces an `ElementsIC` struct.
 
 # Arguments
 - `t0::T` : Initial time [Days].
-- `H::Union{Int64,Vector{Int64},Matrix{<:Real}` : Hierarchy specification. See below and [Examples](@ref)
-- `elems::Elements{T}...` : A sequence of `Elements{T}`. Elements should be passed in the order they appear in the hierarchy (left to right).
-### Hierarchy
-`H::Int64`: The system will be given by a 'fully-nested' Keplerian.
+- `H` : Hierarchy specification.
+- `elems` : The orbital elements and masses of the system.
 
-`H = 4`
+------------
+There are a number of way to specify the initial conditions. Below we've described the arguments `ElementsIC` takes. Any combination of `H` and `elems` may be used. For a concrete example see [Tutorials](@ref).
+
+# Elements
+- `elems...` : A sequence of `Elements{T}`. Elements should be passed in the order they appear in the hierarchy (left to right).
+- `elems::Vector{Elements}` : A vector of `Elements`. As above, Elements should be in order.
+- `elems::Matrix{T}` : An matrix containing the masses and orbital elements.
+- `elems::String` : Name of a file containing the masses and orbital elements.
+
+Each method is simply populating the `ElementsIC.elements` field, which is a `Matrix{T}`.
+
+# Hierarchy
+- Number of bodies: `H::Int64`: The system will be given by a 'fully-nested' Keplerian.
+
+`H = 4` corresponds to:
 ```raw
 3        ____|____
         |         |
@@ -113,7 +125,7 @@ Collects `Elements` and produces an `ElementsIC` struct.
  |     |
  a     b
 ```
-`H::Vector{Int64}`: The first elements is the number of bodies. Each subsequent is the number of binaries on a level of the hierarchy.
+- Hierarchy Vector: `H::Vector{Int64}`: The first elements is the number of bodies. Each subsequent is the number of binaries on a level of the hierarchy.
 
 `H = [4,2,1]`. Two binaries on level 1, one on level 2.
 ```raw
@@ -122,11 +134,10 @@ Collects `Elements` and produces an `ElementsIC` struct.
 1 __|__     __|__
  |     |   |     |
  a     b   c     d
-
-`H::Matrix{<:Real}`: Provide the hierarchy matrix, directly.
+```
+- Full Hierarchy Matrix: `H::Matrix{<:Real}`: Provide the hierarchy matrix, directly.
 
 `H = [-1 1 0 0; 0 0 -1 1; -1 -1 1 1; -1 -1 -1 -1]`. Produces the same system as `H = [4,2,1]`.
-```
 """
 function ElementsIC(t0::T, H::Matrix{<:Real}, elems::Elements{T}...) where T<:AbstractFloat
     elements = zeros(T,size(H)[1],7)
@@ -182,7 +193,7 @@ struct CartesianIC{T<:AbstractFloat} <: InitialConditions{T}
     t0::T
 end
 
-"""Main constructor for `CartesianIC`."""
+"""Allow user to pass matrix of row-vectors for `CartesianIC`."""
 function CartesianIC(t0::T, N::Int64, coords::Matrix{T}) where T<:AbstractFloat
     m = coords[1:N,1]
     x = permutedims(coords[1:N,2:4])

--- a/src/integrator/Integrator.jl
+++ b/src/integrator/Integrator.jl
@@ -21,11 +21,14 @@ mutable struct Integrator{T<:AbstractFloat, schemeT} <: AbstractIntegrator
     tmax::T
 end
 
-Integrator(h::T,t0::T) where T<:AbstractFloat = Integrator(ahl21!,h,t0,t0+h)
-Integrator(scheme,h::Real,t0::Real,tmax::Real) = Integrator(scheme,promote(h,t0,tmax)...)
+Integrator(scheme,h::T,tmax::T) where T<:AbstractFloat = Integrator(scheme,h,0.0,tmax)
+Integrator(h::T,tmax::T) where T<:AbstractFloat = Integrator(ahl21!,h,tmax)
 
 # Default to ahl21!
 Integrator(h::T,t0::T,tmax::T) where T<:AbstractFloat = Integrator(ahl21!,h,t0,tmax)
+
+# Deprecated
+@deprecate Integrator(h,t0,tmax) Integrator(h,tmax)
 
 #========== State ==========#
 abstract type AbstractState end

--- a/src/transits/Transits.jl
+++ b/src/transits/Transits.jl
@@ -2,13 +2,21 @@
 abstract type TransitOutput{T} <: AbstractOutput{T} end
 
 """
+    TransitTiming{T<:AbstractFloat} <: TransitOutput{T}
 
-Holds the transit times and derivatives.
+Transit times and derivatives.
+
+# (User-facing) Fields
+- `tt::Matrix{T}` : The transit times of each body.
+- `dtdq0::Array{T,4}` : Derivatives of the transit times with respect to the initial Cartesian coordinates and masses.
+- `dtdelements::Array{T,4}` : Derivatives of the transit times with respect to the initial orbital elements and masses.
 """
 struct TransitTiming{T<:AbstractFloat} <: TransitOutput{T}
     tt::Matrix{T}
     dtdq0::Array{T,4}
     dtdelements::Array{T,4}
+
+    # Internal
     count::Vector{Int64}
     ntt::Int64
     ti::Int64
@@ -19,7 +27,19 @@ struct TransitTiming{T<:AbstractFloat} <: TransitOutput{T}
     s_transit::State{T}
 end
 
-function TransitTiming(tmax,ic::ElementsIC{T},ti::Int64=1) where T<:AbstractFloat
+"""
+    TransitTiming(tmax, ic; ti)
+
+Constructor for [`TransitTiming`](@ref) type.
+
+# Arguments
+- `tmax::T` : Expected total elapsed integration time. (Allocates arrays accordingly)
+- `ic::ElementsIC{T}` : Initial conditions for the system
+
+## Optional
+- `ti::Int64=1` : Index of the body with respect to which transits are measured. (Default is the central body)
+"""
+function TransitTiming(tmax::T,ic::ElementsIC{T},ti::Int64=1) where T<:AbstractFloat
     n = ic.nbody
     ind = isfinite.(tmax./ic.elements[:,2])
     ntt = maximum(ceil.(Int64,abs.(tmax./ic.elements[ind,2])).+3)
@@ -36,13 +56,21 @@ function TransitTiming(tmax,ic::ElementsIC{T},ti::Int64=1) where T<:AbstractFloa
 end
 
 """
+    TransitParameters{T<:AbstractFloat} <: TransitOutput{T}
 
-Structure for transit timing, impact parameter, and sky velocity
+Transit times, impact parameters, sky-velocities, and derivatives.
+
+# (User-facing) Fields
+- `ttbv::Matrix{T}` : The transit times, impact parameter, and sky-velocity of each body.
+- `dtbvdq0::Array{T,5}` : Derivatives of the transit times, impact parameters, and sky-velocities with respect to the initial Cartesian coordinates and masses.
+- `dtbvdelements::Array{T,5}` : Derivatives of the transit times, impact parameters, and sky-velocities with respect to the initial orbital elements and masses.
 """
 struct TransitParameters{T<:AbstractFloat} <: TransitOutput{T}
     ttbv::Array{T,3}
     dtbvdq0::Array{T,5}
     dtbvdelements::Array{T,5}
+
+    # Internal
     count::Vector{Int64}
     ntt::Int64
     ti::Int64
@@ -53,7 +81,19 @@ struct TransitParameters{T<:AbstractFloat} <: TransitOutput{T}
     s_transit::State{T}
 end
 
-function TransitParameters(tmax,ic::ElementsIC{T},ti::Int64=1) where T<:AbstractFloat
+"""
+    TransitParameters(tmax, ic; ti)
+
+Constructor for [`TransitParameters`](@ref) type.
+
+# Arguments
+- `tmax::T` : Expected total elapsed integration time. (Allocates arrays accordingly)
+- `ic::ElementsIC{T}` : Initial conditions for the system
+
+## Optional
+- `ti::Int64=1` : Index of the body with respect to which transits are measured. (Default is the central body)
+"""
+function TransitParameters(tmax::T,ic::ElementsIC{T},ti::Int64=1) where T<:AbstractFloat
     n = ic.nbody
     ind = isfinite.(tmax./ic.elements[:,2])
     ntt = maximum(ceil.(Int64,abs.(tmax./ic.elements[ind,2])).+3)


### PR DESCRIPTION
- Update main docs page
- Update/add docstrings for (most) user-facing functions (ie. `TransitTiming`, `ElementsIC`, etc.)
- Add transit timing to 'Basic Usage' page
- Add a 'Gradients' page to show how to access derivatives of transit times