### PR TITLE
Normalize computations between gradient and non-gradient versions of AHL21

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NbodyGradient"
 uuid = "69f646f0-5709-4f35-9e52-1656edff0883"
 authors = ["Eric Agol <agol@uw.edu>", "David Hernandez", "Zach Langford <langfzac@uw.edu>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/integrator/ahl21/ahl21.jl
+++ b/src/integrator/ahl21/ahl21.jl
@@ -619,13 +619,13 @@ function phisalpha!(s::State{T},d::AbstractDerivatives{T},h::T,alpha::T) where {
                 @inbounds for di=1:n, p=1:4, k=1:3
                     d.dotdadq[p,di] += s.rij[k]*(d.dadq[k,i,p,di]-d.dadq[k,j,p,di])
                 end
-                r2 = s.rij[1]*s.rij[1]+s.rij[2]*s.rij[2]+s.rij[3]*s.rij[3]
+                r2 = dot_fast(s.rij)
                 r1 = sqrt(r2)
-                ardot = s.aij[1]*s.rij[1]+s.aij[2]*s.rij[2]+s.aij[3]*s.rij[3]
+                ardot = dot_fast(s.aij, s.rij)
                 fac1 = coeff/(r2*r2*r1)
                 fac2 = (2*GNEWT*(s.m[i]+s.m[j])/r1 + 3*ardot)
                 for k=1:3
-                    fac = fac1*(s.rij[k]*fac2- r2*s.aij[k])
+                    fac = fac1*(s.rij[k]*fac2-r2*s.aij[k])
                     s.v[k,i],s.verror[k,i] = comp_sum(s.v[k,i],s.verror[k,i], s.m[j]*fac)
                     s.v[k,j],s.verror[k,j] = comp_sum(s.v[k,j],s.verror[k,j],-s.m[i]*fac)
                     # Compute time derivative:

--- a/test/test_integrator.jl
+++ b/test/test_integrator.jl
@@ -173,4 +173,14 @@
     # Check analytic vs finite difference derivatives
     @test isapprox(asinh.(s0.jac_step), asinh.(jac_step_num);norm=maxabs)
     @test isapprox(s_dt.dqdt, dqdt_num, norm=maxabs)
+
+    # Check that the positions and velocities for the derivatives and non-
+    # derivatives versions match
+    s_nograd = State(ic)
+    s_grad = State(ic)
+    tmax = 2000.0
+    Integrator(h, tmax)(s_nograd, grad=false)
+    Integrator(h, tmax)(s_grad, grad=true)
+    @test s_nograd.x == s_grad.x
+    @test s_nograd.v == s_grad.v
 end

--- a/test/test_transit_timing.jl
+++ b/test/test_transit_timing.jl
@@ -87,4 +87,12 @@ import NbodyGradient: set_state!, zero_out!, amatrix, initialize!
         @test isapprox(asinh.(tts[1].dtdelements[mask]), asinh.(dtde_num[mask]);norm=maxabs)
         @test isapprox(asinh.(tts[1].dtdelements), asinh.(dtde_num);norm=maxabs)
     end
+
+    # Test that the transit times for the derivatives and non-derivatives match
+    tmax = 2000.0
+    s_nograd = State(ic); tt_nograd = TransitTiming(tmax, ic);
+    s_grad = State(ic); tt_grad = TransitTiming(tmax, ic);
+    Integrator(h, tmax)(s_nograd, tt_nograd, grad=false)
+    Integrator(h, tmax)(s_grad, tt_grad, grad=true)
+    @test tt_nograd.tt == tt_grad.tt
 end


### PR DESCRIPTION
- Fix the `fac` computations in `phic!` and `phisalpha!` in non-gradient integrator to match the gradient version.
- Add tests to ensure positions, velocities, and transit times match for gradient and non-gradient versions. 