### PR TITLE
Fix up initial conditions

### DIFF
--- a/docs/src/basic.md
+++ b/docs/src/basic.md
@@ -24,21 +24,21 @@ b = Elements(
     m = 3e-6,     # Mass [Solar masses]
     t0 = 0.0,     # Initial time of transit [days]
     P = 365.256,  # Period [days]
-    ecosϖ = 0.01, # Eccentricity * cos(Argument of Periastron)
-    esinϖ = 0.0,  # Eccentricity * sin(Argument of Periastron)
+    ecosω = 0.01, # Eccentricity * cos(Argument of Periastron)
+    esinω = 0.0,  # Eccentricity * sin(Argument of Periastron)
     I = π/2,      # Inclination [Radians]
     Ω = 0.0       # Longitude of Ascending Node [Radians]
 );
 nothing # hide
 ```
-(`ecosϖ` can be typed as `ecos\varpi` and then hitting tab)
+(`ecosω` can be typed as `ecos\omega` and then hitting tab)
 
 Next we'll create a Jupiter analogue for the final body. Here the orbital elements are specified for the Keplerian ((a,b),c), or c orbiting the center of mass of a and b. (While this might not need to be stated explicitly here, this convention is useful for more complicated hierarchical systems).
 ```@example 1
 c = Elements(
     m = 9.54e-4,
     P = 4332.59,
-    ecosϖ = 0.05,
+    ecosω = 0.05,
     I = π/2
 );
 nothing # hide

--- a/docs/src/gradients.md
+++ b/docs/src/gradients.md
@@ -9,7 +9,7 @@ using NbodyGradient
 
 # Initial Conditions
 elements = [
-  # m    P       t0  ecosϖ esinϖ I   Ω
+  # m    P       t0  ecosω esinω I   Ω
     1.0  0.0     0.0 0.0   0.0   0.0 0.0; # Star
     3e-6 365.256 0.0 0.01  0.0   π/2 0.0; # Earth analogue
 ]

--- a/docs/src/gradients.md
+++ b/docs/src/gradients.md
@@ -3,6 +3,9 @@ The main purpose of developing NbodyGradient.jl is to provide a differentiable N
 
 We assume you've taken a look at the [Basic Usage](@ref) tutorial, and are familiar with the orbital elements and units used in NbodyGradient.jl.
 
+!!! note "No gradient support for exactly circular orbits"
+    This package supports specifying initial conditions for circular orbits (ie. eccentricity=0). However, the derivative computations contain 1/e terms -- requiring a non-zero eccentricity to be computed correctly. We expect the need for derivatives for exactly circular initial orbits to be minimal, and intend to implement them in the future.
+
 Here, we will specify the orbital elements using the 'elements matrix' option (See [`ElementsIC`](@ref)).
 ```@example 2
 using NbodyGradient

--- a/src/ics/InitialConditions.jl
+++ b/src/ics/InitialConditions.jl
@@ -106,6 +106,23 @@ function Elements(;m::Real,P::Real=NaN,t0::Real=NaN,ecosω::Real=NaN,esinω::Rea
     return Elements(m,P,t0,ecosω,esinω,I,Ω,a,e,ω,tp)
 end
 
+# Handle the deprecated fields
+function Base.getproperty(obj::Elements, sym::Symbol)
+    if (sym === :ecosϖ)
+        Base.depwarn("ecosϖ (\\varpi) will be removed, use ecosω (\\omega).", :getproperty, force=true)
+        return obj.ecosω
+    end
+    if (sym === :esinϖ)
+        Base.depwarn("esinϖ (\\varpi) will be removed, use esinω (\\omega).", :getproperty, force=true)
+        return obj.esinω
+    end
+    if (sym === :ϖ)
+        Base.depwarn("ϖ (\\varpi) will be removed, use ω (\\omega).", :getproperty, force=true)
+        return obj.ω
+    end
+    return getfield(obj, sym)
+end
+
 """Abstract type for initial conditions specifications."""
 abstract type InitialConditions{T} end
 

--- a/src/ics/InitialConditions.jl
+++ b/src/ics/InitialConditions.jl
@@ -9,8 +9,8 @@ Orbital elements of a binary, and mass of a 'outer' body. See [Tutorials](@ref) 
 - `m::T` : Mass of outer body.
 - `P::T` : Period [Days].
 - `t0::T` : Initial time of transit [Days].
-- `ecosω` : Eccentricity vector x-component (eccentricity times cosine of the argument of periastron)
-- `esinω` : Eccentricity vector y-component (eccentricity times sine of the argument of periastron)
+- `ecosω::T` : Eccentricity vector x-component (eccentricity times cosine of the argument of periastron)
+- `esinω::T` : Eccentricity vector y-component (eccentricity times sine of the argument of periastron)
 - `I::T` : Inclination, as measured from sky-plane [Radians].
 - `Ω::T` : Longitude of ascending node, as measured from +x-axis [Radians].
 - `a::T` : Orbital semi-major axis [AU].

--- a/src/ics/InitialConditions.jl
+++ b/src/ics/InitialConditions.jl
@@ -9,36 +9,36 @@ Orbital elements of a binary, and mass of a 'outer' body. See [Tutorials](@ref) 
 - `m::T` : Mass of outer body.
 - `P::T` : Period [Days].
 - `t0::T` : Initial time of transit [Days].
-- `ecosϖ` : Eccentricity vector x-component (eccentricity times cosine of the longitude of periastron)
-- `esinϖ` : Eccentricity vector y-component (eccentricity times sine of the longitude of periastron)
+- `ecosω` : Eccentricity vector x-component (eccentricity times cosine of the argument of periastron)
+- `esinω` : Eccentricity vector y-component (eccentricity times sine of the argument of periastron)
 - `I::T` : Inclination, as measured from sky-plane [Radians].
 - `Ω::T` : Longitude of ascending node, as measured from +x-axis [Radians].
 - `a::T` : Orbital semi-major axis [AU].
 - `e::T` : Eccentricity.
-- `ϖ::T` : Longitude of periastron [Radians].
+- `ω::T` : Argument of periastron [Radians].
 """
 struct Elements{T<:AbstractFloat} <: AbstractInitialConditions
     m::T
     P::T
     t0::T
-    ecosϖ::T
-    esinϖ::T
+    ecosω::T
+    esinω::T
     I::T
     Ω::T
     a::T
     e::T
-    ϖ::T
+    ω::T
 end
 
 """
-    Elements(m,P,t0,ecosϖ,esinϖ,I,Ω)
+    Elements(m,P,t0,ecosω,esinω,I,Ω)
 
 Main [`Elements`](@ref) constructor. May use keyword arguments, see [Tutorials](@ref).
 """
-function Elements(m::T,P::T,t0::T,ecosϖ::T,esinϖ::T,I::T,Ω::T) where T<:Real
-    e = sqrt(ecosϖ^2 + esinϖ^2)
-    ϖ = atan(esinϖ,ecosϖ)
-    Elements(m,P,t0,ecosϖ,esinϖ,I,Ω,0.0,e,ϖ)
+function Elements(m::T,P::T,t0::T,ecosω::T,esinω::T,I::T,Ω::T) where T<:Real
+    e = sqrt(ecosω^2 + esinω^2)
+    ω = atan(esinω,ecosω)
+    Elements(m,P,t0,ecosω,esinω,I,Ω,0.0,e,ω)
 end
 
 function Base.show(io::IO, ::MIME"text/plain" ,elems::Elements{T}) where T <: Real
@@ -55,7 +55,7 @@ function Base.show(io::IO, ::MIME"text/plain" ,elems::Elements{T}) where T <: Re
 end
 
 """Allows keyword arguments"""
-Elements(;m::T=0.0,P::T=0.0,t0::T=0.0,ecosϖ::T=0.0,esinϖ::T=0.0,I::T=0.0,Ω::T=0.0) where T<:Real = Elements(m,P,t0,ecosϖ,esinϖ,I,Ω)
+Elements(;m::T=0.0,P::T=0.0,t0::T=0.0,ecosω::T=0.0,esinω::T=0.0,I::T=0.0,Ω::T=0.0) where T<:Real = Elements(m,P,t0,ecosω,esinω,I,Ω)
 
 """Abstract type for initial conditions specifications."""
 abstract type InitialConditions{T} end
@@ -146,7 +146,7 @@ Each method is simply populating the `ElementsIC.elements` field, which is a `Ma
 """
 function ElementsIC(t0::T, H::Matrix{<:Real}, elems::Elements{T}...) where T<:AbstractFloat
     elements = zeros(T,size(H)[1],7)
-    fields = [:m, :P, :t0, :ecosϖ, :esinϖ, :I, :Ω]
+    fields = [:m, :P, :t0, :ecosω, :esinω, :I, :Ω]
     for i in eachindex(elems)
         elements[i,:] .= [getfield(elems[i],f) for f in fields]
     end

--- a/src/outputs/elements.jl
+++ b/src/outputs/elements.jl
@@ -76,8 +76,7 @@ function calc_ω(x,R,Rdot,I,Ω,a,e,h)
     cosf = (a*(1.0-e^2)/R - 1.0)/e
     f = atan(sinf,cosf)
 
-    # ω = Ω + ω
-    return Ω + wpf - f
+    return wpf - f
 end
 
 function convert_to_elements(x,v,M)
@@ -97,9 +96,13 @@ function convert_to_elements(x,v,M)
     I != 0.0 ? Ω = calc_Ω(hx,hy,h,I) : Ω = 0.0
 
     ω = calc_ω(x,R,Rdot,I,Ω,a,e,h)
-    P = (2.0*ω)*sqrt(a*a*a/Gmm)
+    P = (2.0*π)*sqrt(a*a*a/Gmm)
 
-    return [P,0.0,e*cos(ω),e*sin(ω),I,Ω,a,e,ω]
+    n = 2π/P
+    ecosω, esinω = e.*sincos(ω)
+    tp = (-sqrt(1.0-e*e)*ecosω/(n*(1.0-esinω)) - (2.0/n)*atan(sqrt(1.0-e)*(esinω+ecosω+e), sqrt(1.0+e)*(esinω-ecosω-e))) % P
+
+    return [P,0.0,ecosω,esinω,I,Ω,a,e,ω,tp]
 end
 
 function get_orbital_elements(s::State{T},ic::InitialConditions{T}) where T<:AbstractFloat

--- a/test/test_initial_conditions.jl
+++ b/test/test_initial_conditions.jl
@@ -154,4 +154,11 @@ end
     @testset "Defaults" begin
         test_default_trappist()
     end
+
+    @testset "Deprecated" begin
+        el = Elements(m=1.0, P=1.0)
+        @test_logs (:warn, "ecosϖ (\\varpi) will be removed, use ecosω (\\omega).") Base.getproperty(el, :ecosϖ)
+        @test_logs (:warn, "esinϖ (\\varpi) will be removed, use esinω (\\omega).") Base.getproperty(el, :esinϖ)
+        @test_logs (:warn, "ϖ (\\varpi) will be removed, use ω (\\omega).") Base.getproperty(el, :ϖ)
+    end
 end

--- a/test/test_initial_conditions.jl
+++ b/test/test_initial_conditions.jl
@@ -28,7 +28,7 @@ function get_elements_ic_elems(t0, H, N)
     elements = readdlm(fname, ',', comments=true)
     elems = Elements{Float64}[]
     for i in 1:N
-        push!(elems, Elements(elements[i,:]...))
+        push!(elems, Elements(elements[i,:]..., zeros(4)...))
     end
     ic = ElementsIC(t0, H, elems)
     return ic


### PR DESCRIPTION
- [x] Allow integers to be given as parameter values (ie. `Elements(m=1)`).
- [x] Change `ϖ` (`\varpi`) to `ω` (`\omega`) in code and fix terminology in docs.
- [x] #83 
  - [x] Add additional orbital elements to `Elements` type.
  - [x] Rework `kepler_init` to handle `e=0`.