### PR TITLE
Fixing starting guess for transit time

### DIFF
--- a/src/transits/timing.jl
+++ b/src/transits/timing.jl
@@ -17,7 +17,7 @@ function detect_transits!(s::State{T},d::Derivatives{T},tt::TransitOutput{T},int
             # A transit has occurred between the time steps - integrate ahl21!
             tt.count[i] += 1
             if tt.count[i] <= tt.ntt
-                dt0 = -tt.gsave[i]*intr.h/(gi-tt.gsave[i]) # Starting estimate
+                dt0 = -gi*intr.h/(gi-tt.gsave[i]) # Starting estimate
                 set_state!(s,tt.s_prior)
                 findtransit!(tt.ti,i,dt0,s,d,tt,intr;grad=grad) # Search for transit time (integrating 'backward')
             end


### PR DESCRIPTION
There was a typo in the starting guess for the transit time found by interpolation.

This arose when we switched from integrating forwards in time to integrating
backwards in time to find the time of transit.

This branch fixes this issue.

We should make sure that this fix makes its way into the other branches (maybe we can delete some of the other branches at this time?).